### PR TITLE
Fixed the selection color of a folded block #30

### DIFF
--- a/src/omni.yml
+++ b/src/omni.yml
@@ -187,7 +187,7 @@ colors:
   editor.selectionBackground: *SELECTION                                        # Color of the editor selection
   editor.selectionHighlightBackground: *BGLighter                               # Color for regions with the same content as the selection
   editor.inactiveSelectionBackground:                                           # Color of the selection in an inactive editor
-  editor.foldBackground: *BGDark                                                # Background color for folded ranges
+  editor.foldBackground: !alpha [*BGDark, 40]                                   # Background color for folded ranges
 
   editor.wordHighlightBackground: !alpha [ *CYAN, 50 ]                          # Background color of a symbol during read-access, for example when reading a variable
   editor.wordHighlightStrongBackground: !alpha [ *GREEN, 50 ]                   # Background color of a symbol during write-access, for example when writing to a variable


### PR DESCRIPTION
Changes proposed
This PR fixes the selection color of a folded block in the editor. Previously, the selection color was inconsistent with the theme, making it difficult to distinguish selected text within collapsed sections.

The updated color ensures better readability and consistency with the overall design.

Fixes #30

Additional context
Before the fix:
![image](https://github.com/user-attachments/assets/4cae7836-f8fc-434c-8431-13c297c56c14)

After the fix:
![image](https://github.com/user-attachments/assets/c50d8d0a-e8ad-48e3-82d0-50142fd479ef)

This change enhances the user experience by improving the visibility of selected text in folded blocks, maintaining color consistency across the editor.